### PR TITLE
Offer to install unix utilities (#176)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ If you're setting up an engineering machine choose which languages to install:
 
 ```sh
 # For Labs developers (remove unnecessary languages when running command)
-./setup.sh developer java ruby node golang c docker
+./setup.sh java ruby node golang c docker
 
 # For Data developers
-./setup.sh developer c golang java docker
+./setup.sh c golang java docker
 
 # If you want java 8, you can use
-./setup.sh developer java8
+./setup.sh java8
 ```
 
 The list of Engineering applications is found in: [applications-common.sh](https://github.com/pivotal/workstation-setup/blob/master/scripts/common/applications-common.sh)

--- a/scripts/common/unix.sh
+++ b/scripts/common/unix.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+echo
+echo "Installing utilities for unix development"
+
+# For users of unixes
+brew install pstree
+
+# For developers of shell scripts
+brew install jq

--- a/scripts/opt-in/developer.sh
+++ b/scripts/opt-in/developer.sh
@@ -1,1 +1,0 @@
-#!/usr/bin/env bash

--- a/setup.sh
+++ b/setup.sh
@@ -25,6 +25,7 @@ source ${MY_DIR}/scripts/common/git.sh
 source ${MY_DIR}/scripts/common/git-aliases.sh
 source ${MY_DIR}/scripts/common/cloud-foundry.sh
 source ${MY_DIR}/scripts/common/applications-common.sh
+source ${MY_DIR}/scripts/common/unix.sh
 source ${MY_DIR}/scripts/common/configuration-osx.sh
 source ${MY_DIR}/scripts/common/configurations.sh
 


### PR DESCRIPTION
* Offer to install unix utilities

For people who develop on a unix, or develop for a unix

Repurpose the empty developer.sh while still maintaining back-compatibility

Author: C.J. Jameson <cjameson@pivotal.io>

* Promote unix.sh to be a common script

developer.sh had been deprecated; fully remove it

Author: C.J. Jameson <cjameson@pivotal.io>